### PR TITLE
Fix regular failing spec with preview_mt (#8592)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
       - run: echo 'export CURRENT_TAG="$CIRCLE_TAG"' >> $BASH_ENV
       - run: bin/ci prepare_build
       - run: bin/ci with_build_env 'make crystal'
-      - run: bin/ci with_build_env 'CRYSTAL_WORKERS=4 make std_spec threads=1 verbose=1 FLAGS="-D preview_mt"'
+      - run: bin/ci with_build_env 'CRYSTAL_WORKERS=4 make std_spec threads=1 FLAGS="-D preview_mt"'
 
   check_format:
     machine: true

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -65,11 +65,21 @@ describe HTTP::Server do
       ch.send :end
     end
 
+    # wait for the server to start listening, and a little longer
+    # so the spawn that performs the accept has chance to run
+    while !server.listening?
+      Fiber.yield
+    end
+    sleep 0.1
+
     delay(1) { ch.send :timeout }
 
     TCPSocket.open(address.address, address.port) { }
 
+    # wait before closing the server
+    sleep 0.1
     server.close
+
     ch.receive.should eq(:end)
   end
 


### PR DESCRIPTION
* CI: Turn off verbose output in preview_mt specs

* Wait for server to listen on HTTP::Server close spec

and wait before closing it

* Reduce sleep time