### PR TITLE
Spec::JUnitFormatter enhancements (#8599)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ progress ?=     ## Enable progress output
 threads ?=      ## Maximum number of threads to use
 debug ?=        ## Add symbolic debug info
 verbose ?=      ## Run specs in verbose mode
-junit_output ?= ## Directory to output junit results
+junit_output ?= ## Path to output junit results
 static ?=       ## Enable static linking
 
 O := .build

--- a/spec/std/spec/tap_formatter_spec.cr
+++ b/spec/std/spec/tap_formatter_spec.cr
@@ -5,7 +5,7 @@ private def build_report
   String.build do |io|
     formatter = Spec::TAPFormatter.new(io)
     yield formatter
-    formatter.finish
+    formatter.finish(Time::Span.zero, false)
   end
 end
 

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -129,8 +129,8 @@ OptionParser.parse do |opts|
       abort("order must be either 'default', 'random', or a numeric seed value")
     end
   end
-  opts.on("--junit_output OUTPUT_DIR", "generate JUnit XML output") do |output_dir|
-    junit_formatter = Spec::JUnitFormatter.file(output_dir)
+  opts.on("--junit_output OUTPUT_PATH", "generate JUnit XML output within the given OUTPUT_PATH") do |output_path|
+    junit_formatter = Spec::JUnitFormatter.file(Path.new(output_path))
     Spec.add_formatter(junit_formatter)
   end
   opts.on("--help", "show this help") do |pattern|

--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -65,7 +65,7 @@ module Spec
     end
 
     def finish(elapsed_time, aborted = false)
-      Spec.formatters.each(&.finish)
+      Spec.formatters.each(&.finish(elapsed_time, aborted))
       Spec.formatters.each(&.print_results(elapsed_time, aborted))
     end
 

--- a/src/spec/example.cr
+++ b/src/spec/example.cr
@@ -45,19 +45,17 @@ module Spec
     end
 
     private def internal_run(start, block)
-      begin
-        @parent.run_before_each_hooks
-        block.call
-        @parent.report(:success, description, file, line, Time.monotonic - start)
-      rescue ex : Spec::AssertionFailed
-        @parent.report(:fail, description, file, line, Time.monotonic - start, ex)
-        Spec.abort! if Spec.fail_fast?
-      rescue ex
-        @parent.report(:error, description, file, line, Time.monotonic - start, ex)
-        Spec.abort! if Spec.fail_fast?
-      ensure
-        @parent.run_after_each_hooks
-      end
+      @parent.run_before_each_hooks
+      block.call
+      @parent.report(:success, description, file, line, Time.monotonic - start)
+    rescue ex : Spec::AssertionFailed
+      @parent.report(:fail, description, file, line, Time.monotonic - start, ex)
+      Spec.abort! if Spec.fail_fast?
+    rescue ex
+      @parent.report(:error, description, file, line, Time.monotonic - start, ex)
+      Spec.abort! if Spec.fail_fast?
+    ensure
+      @parent.run_after_each_hooks
     end
   end
 end

--- a/src/spec/formatter.cr
+++ b/src/spec/formatter.cr
@@ -16,7 +16,7 @@ module Spec
     def report(result)
     end
 
-    def finish
+    def finish(elapsed_time, aborted)
     end
 
     def print_results(elapsed_time : Time::Span, aborted : Bool)
@@ -30,7 +30,7 @@ module Spec
       @io.flush
     end
 
-    def finish
+    def finish(elapsed_time, aborted)
       @io.puts
     end
 

--- a/src/spec/tap_formatter.cr
+++ b/src/spec/tap_formatter.cr
@@ -23,7 +23,7 @@ class Spec::TAPFormatter < Spec::Formatter
     @io.puts
   end
 
-  def finish
+  def finish(elapsed_time, aborted)
     @io << "1.." << @counter
     @io.puts
   end


### PR DESCRIPTION
* Forward arguments to formatter finish method

* Report elapsed time in Spec::JUnitFormatter

* Report number of pending specs (as “disabled”) in Spec::JUnitFormatter

* Output errored class name as an “error[type]” attribute

* Remove redundant `begin … end`

* Output hostname for testsuite in Spec::JUnitFormatter

* Move `#chomp` call to the helper

* Output timestamp for testsuite in Spec::JUnitFormatter

* Correctly report pending testcases as “skipped”

* Strip current working directory from reported “testcase[classname]” attribute

* Remove timestamp attribute mocking in specs since it ain’t test anything rly

* Add specs for Spec::JUnitFormatter#classname

* Consistently use “skipped”

* Use .total_seconds for moar clarity

* Escape control characters for “testcase[name]”

* Add `—junit_output_path` for more granular control of the junit output location

* Change `—junit_output` to take full path to the junit xml file

* Properly mock `Spec::JUnitFormatter#started_at`