### PR TITLE
Add Enum.new(self) for auto-casting in macro-generated code (#8634)

### DIFF
--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -37,6 +37,11 @@ describe Enum do
     end
   end
 
+  it "creates an enum instance from an auto-casted symbol (#8573)" do
+    enum_value = SpecEnum.new(:two)
+    enum_value.should eq SpecEnum::Two
+  end
+
   it "gets value" do
     SpecEnum::Two.value.should eq(1)
     SpecEnum::Two.value.should be_a(Int8)

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -89,6 +89,11 @@
 struct Enum
   include Comparable(self)
 
+  # Returns *value*.
+  def self.new(value : self)
+    value
+  end
+
   # Appends a `String` representation of this enum member to the given *io*.
   #
   # See also: `to_s`.


### PR DESCRIPTION
* Allow to create an enum from a macro symbol

* Rename method and simplify doc

* Simplify spec