### PR TITLE
Fix #8637: Null added if str.sub(Hash) match last char (#8644)

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1317,6 +1317,26 @@ describe "String" do
     it "subs beginless range with string" do
       "hello".sub(nil..2, "ye").should eq("yelo")
     end
+
+    it "subs the last char" do
+      str = "hello"
+      str.sub('o', 'a').should eq("hella")
+      str.sub('o', "ad").should eq("hellad")
+      str.sub(4, 'a').should eq("hella")
+      str.sub(4, "ad").should eq("hellad")
+      str.sub(4..4, 'a').should eq("hella")
+      str.sub(4..4, "ad").should eq("hellad")
+      str.sub({'a' => 'b', 'o' => 'a'}).should eq("hella")
+      str.sub({'a' => 'b', 'o' => "ad"}).should eq("hellad")
+      str.sub(/o/, 'a').should eq("hella")
+      str.sub(/o/, "ad").should eq("hellad")
+      str.sub(/o/) { 'a' }.should eq("hella")
+      str.sub(/o/) { "ad" }.should eq("hellad")
+      str.sub(/(o)/, {"o" => 'a'}).should eq("hella")
+      str.sub(/(o)/, {"o" => "ad"}).should eq("hellad")
+      str.sub(/(o)/) { 'a' }.should eq("hella")
+      str.sub(/(o)/) { "ad" }.should eq("hellad")
+    end
   end
 
   describe "gsub" do

--- a/src/string.cr
+++ b/src/string.cr
@@ -1853,9 +1853,8 @@ class String
         end
       end
 
-      buffer << reader.current_char
-
       if reader.has_next?
+        buffer << reader.current_char
         reader.next_char
         buffer.write unsafe_byte_slice(reader.pos)
       end


### PR DESCRIPTION
* Fix #8637: Null added if str.sub(Hash) match last char

Example:
  "helloC".sub({'C' => 'G'}) # => "helloG\u0000"

* Add specs for all sub overloads