### PR TITLE
IO: Set fd to -1 on closed File/Socket (#8873)

### DIFF
--- a/spec/std/socket/unix_server_spec.cr
+++ b/spec/std/socket/unix_server_spec.cr
@@ -1,6 +1,7 @@
 require "spec"
 require "socket"
 require "../../support/errno"
+require "../../support/fibers"
 require "../../support/tempfile"
 
 describe UNIXServer do

--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -173,7 +173,7 @@ module Crystal::System::File
   private def flock(op : LibC::FlockOp, blocking : Bool = true)
     op |= LibC::FlockOp::NB unless blocking
 
-    if LibC.flock(@fd, op) != 0
+    if LibC.flock(fd, op) != 0
       raise Errno.new("flock")
     end
 

--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -213,7 +213,7 @@ module Crystal::System::File
   end
 
   private def system_truncate(size : Int) : Nil
-    if LibC._chsize(@fd, size) != 0
+    if LibC._chsize(fd, size) != 0
       raise Errno.new("Error truncating file #{path.inspect}")
     end
   end

--- a/src/file.cr
+++ b/src/file.cr
@@ -785,7 +785,7 @@ class File < IO::FileDescriptor
       raise ArgumentError.new("Bytesize out of bounds")
     end
 
-    io = PReader.new(fd, offset, bytesize)
+    io = PReader.new(self, offset, bytesize)
     yield io ensure io.close
   end
 

--- a/src/file/preader.cr
+++ b/src/file/preader.cr
@@ -4,7 +4,7 @@ class File::PReader < IO
 
   getter? closed = false
 
-  def initialize(@fd : Int32, @offset : Int32, @bytesize : Int32)
+  def initialize(@file : File, @offset : Int32, @bytesize : Int32)
     @pos = 0
   end
 
@@ -14,7 +14,7 @@ class File::PReader < IO
     count = slice.size
     count = Math.min(count, @bytesize - @pos)
 
-    bytes_read = Crystal::System::FileDescriptor.pread(@fd, slice[0, count], @offset + @pos)
+    bytes_read = Crystal::System::FileDescriptor.pread(@file.fd, slice[0, count], @offset + @pos)
 
     @pos += bytes_read
 

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -7,9 +7,12 @@ class IO::FileDescriptor < IO
 
   # The raw file-descriptor. It is defined to be an `Int`, but its size is
   # platform-specific.
-  getter fd
+  def fd
+    @volatile_fd.get
+  end
 
-  def initialize(@fd, blocking = nil)
+  def initialize(fd, blocking = nil)
+    @volatile_fd = Atomic.new(fd)
     @closed = system_closed?
 
     if blocking.nil?
@@ -69,7 +72,7 @@ class IO::FileDescriptor < IO
     end
 
     def fcntl(cmd, arg = 0)
-      Crystal::System::FileDescriptor.fcntl(@fd, cmd, arg)
+      Crystal::System::FileDescriptor.fcntl(fd, cmd, arg)
     end
   {% end %}
 
@@ -171,7 +174,7 @@ class IO::FileDescriptor < IO
     if closed?
       io << "(closed)"
     else
-      io << " fd=" << @fd
+      io << " fd=" << fd
     end
     io << '>'
   end


### PR DESCRIPTION
* Avoid keeping a fd of a potentially closed File

* Set fd to -1 before closing the file_descriptor / socket

This is to reduce the chance of reading an outdated fd value

* Allow unix_server_spec to be run independently

* Use atomic to store the fd in file and socket

This will force a volatile semantic over the value and prevent using an outdated value across multiple threads.