### PR TITLE
Serialize Enum to underscored String by default (#10431)

### DIFF
--- a/spec/std/json/pull_parser_spec.cr
+++ b/spec/std/json/pull_parser_spec.cr
@@ -379,4 +379,15 @@ describe JSON::PullParser do
       pull.read?(Float32).should be_nil
     end
   end
+
+  it "#raise" do
+    pull = JSON::PullParser.new("[1, 2, 3]")
+    expect_raises(JSON::ParseException, "foo bar at line 1, column 2") do
+      pull.raise "foo bar"
+    end
+    pull.read_begin_array
+    expect_raises(JSON::ParseException, "foo bar at line 1, column 3") do
+      pull.raise "foo bar"
+    end
+  end
 end

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -243,14 +243,72 @@ def NamedTuple.new(pull : JSON::PullParser)
   {% end %}
 end
 
+# Reads a serialized enum member by name from *pull*.
+#
+# See `#to_json` for reference.
+#
+# Raises `JSON::ParseException` if the deserialization fails.
 def Enum.new(pull : JSON::PullParser)
-  case pull.kind
-  when .int?
-    from_value(pull.read_int)
-  when .string?
-    parse(pull.read_string)
-  else
-    raise "Expecting int or string in JSON for #{self.class}, not #{pull.kind}"
+  {% if @type.annotation(Flags) %}
+    value = {{ @type }}::None
+    pull.read_array do
+      value |= parse?(pull.read_string) || pull.raise "Unknown enum #{self} value: #{pull.string_value.inspect}"
+    end
+    value
+  {% else %}
+    parse?(pull.read_string) || pull.raise "Unknown enum #{self} value: #{pull.string_value.inspect}"
+  {% end %}
+end
+
+# Converter for value-based serialization and deserialization of enum type `T`.
+#
+# The serialization format of `Enum#to_json` and `Enum.from_json` is based on
+# the member name. This converter offers an alternative based on the member value.
+#
+# This converter can be used for its standalone serialization methods as a
+# replacement of the default strategy of `Enum`. It also works as a serialization
+# converter with `JSON::Field` and `YAML::Field`
+#
+# ```
+# require "json"
+# require "yaml"
+#
+# enum MyEnum
+#   ONE = 1
+#   TWO = 2
+# end
+#
+# class Foo
+#   include JSON::Serializable
+#   include YAML::Serializable
+#
+#   @[JSON::Field(converter: Enum::ValueConverter(MyEnum))]
+#   @[YAML::Field(converter: Enum::ValueConverter(MyEnum))]
+#   property foo : MyEnum = MyEnum::ONE
+# end
+#
+# foo = Foo.new
+# foo.to_json # => %({"my_enum":1})
+# foo.to_yaml # => %(---\nmy_enum: 1\n)
+# ```
+#
+# NOTE: Automatically assigned enum values are subject to change when the order
+# of members by adding, removing or reordering them. This can affect the integrity
+# of serialized data between two instances of a program based on different code
+# versions. A way to avoid this is to explicitly assign fixed values to enum
+# members.
+module Enum::ValueConverter(T)
+  def self.new(pull : JSON::PullParser) : T
+    from_json(pull)
+  end
+
+  # Reads a serialized enum member by value from *pull*.
+  #
+  # See `.to_json` for reference.
+  #
+  # Raises `JSON::ParseException` if the deserialization fails.
+  def self.from_json(pull : JSON::PullParser) : T
+    T.from_value?(pull.read_int) || pull.raise "Unknown enum #{T} value: #{pull.int_value}"
   end
 end
 

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -219,7 +219,7 @@ class JSON::PullParser
     when .float?
       @float_value.tap { read_next }
     else
-      parse_exception "expecting int or float but was #{@kind}"
+      raise "expecting int or float but was #{@kind}"
     end
   end
 
@@ -679,20 +679,21 @@ class JSON::PullParser
   end
 
   private def expect_kind(kind : Kind)
-    parse_exception "Expected #{kind} but was #{@kind}" unless @kind == kind
+    raise "Expected #{kind} but was #{@kind}" unless @kind == kind
   end
 
   private def unexpected_token
-    parse_exception "Unexpected token: #{token}"
+    raise "Unexpected token: #{token}"
   end
 
-  private def parse_exception(msg)
-    raise ParseException.new(msg, token.line_number, token.column_number)
+  # Raises `ParseException` with *message* at current location.
+  def raise(message : String)
+    ::raise ParseException.new(message, token.line_number, token.column_number)
   end
 
   private def push_in_object_stack(kind : ObjectStackKind)
     if @object_stack.size >= @max_nesting
-      parse_exception "Nesting of #{@object_stack.size + 1} is too deep"
+      raise "Nesting of #{@object_stack.size + 1} is too deep"
     end
 
     @object_stack.push(kind)


### PR DESCRIPTION
* Serialize Enum to underscored String by default

* Quote enums that serialise to YAML keywords

* Account for libyaml version

Co-authored by straightshoota@gmail.com

* Serialize Flags enums to and from json as an array

* Serialize Flags enums to and from yaml as an array

* Sum parsed flag enum members before calling `from_value`

* Add JSON::PullParser#raise

* Add YAML::Nodes::Node#type

* Improve specs and more strict implementation

* Remove unnecessary token checks in JSON impl.

* crystal tool format

* Refactor to NumberConverter and simplify deserialization code

* [CI] Print libyaml version

* Fix spec libyaml compat

* Add documentation

* Update specs after #10432

Co-authored-by: Caspian Baska <caspianbaska@gmail.com>