### PR TITLE
Docs: detect source locations in more situations (#10439)

### DIFF
--- a/spec/compiler/crystal/tools/doc/project_info_spec.cr
+++ b/spec/compiler/crystal/tools/doc/project_info_spec.cr
@@ -73,11 +73,21 @@ describe Crystal::Doc::ProjectInfo do
         run_git "add shard.yml"
         run_git "commit -m \"Initial commit\" --no-gpg-sign"
         run_git "tag v3.0"
-        File.write("foo.txt", "bar")
+        File.write("shard.yml", "\n", mode: "a")
 
         assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new("foo", "3.0-dev", refname: nil))
         assert_with_defaults(ProjectInfo.new(nil, "1.1"), ProjectInfo.new("foo", "1.1", refname: nil))
         assert_with_defaults(ProjectInfo.new("bar", "2.0"), ProjectInfo.new("bar", "2.0", refname: nil))
+      end
+
+      it "git untracked file doesn't prevent detection" do
+        run_git "init"
+        run_git "add shard.yml"
+        run_git "commit -m \"Initial commit\" --no-gpg-sign"
+        run_git "tag v3.0"
+        File.write("foo.txt", "bar")
+
+        assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new("foo", "3.0", refname: "v3.0"))
       end
 
       it "git non-tagged commit" do
@@ -96,7 +106,7 @@ describe Crystal::Doc::ProjectInfo do
         run_git "init"
         run_git "add shard.yml"
         run_git "commit -m \"Initial commit\" --no-gpg-sign"
-        File.write("foo.txt", "bar")
+        File.write("shard.yml", "\n", mode: "a")
 
         assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new("foo", "master-dev", refname: nil))
         assert_with_defaults(ProjectInfo.new(nil, "1.1"), ProjectInfo.new("foo", "1.1", refname: nil))

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -382,9 +382,7 @@ class Crystal::Doc::Generator
       filename = location.filename
       next unless filename
 
-      url = project_info.source_url(location)
-      next unless url
-      location.url = url
+      location.url = project_info.source_url(location)
 
       # Prevent identical link generation in the "Defined in:" section in the docs because of macros
       next if locations.includes?(location)

--- a/src/compiler/crystal/tools/doc/project_info.cr
+++ b/src/compiler/crystal/tools/doc/project_info.cr
@@ -131,7 +131,7 @@ module Crystal::Doc
     def self.git_clean?
       # Use git to determine if index and working directory are clean
       # In case the command failed to execute or returned error status, return false
-      capture = Crystal::Git.git_capture(["status", "--porcelain"]) || return false
+      capture = Crystal::Git.git_capture(["status", "--porcelain", "--untracked-files=no"]) || return false
 
       # Index is clean if output is empty (and program status is success, checked by git_capture)
       capture.bytesize == 0


### PR DESCRIPTION
* Report locations (just without URLs) even if --source-refname wasn't specified or detected
* Don't consider the presence of untracked files as making a revision dirty