### PR TITLE
Add @top_level to access the top-level scope in macros (#10682)

### DIFF
--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -1876,4 +1876,29 @@ describe "Code gen: macro" do
       foo
     )).to_string.should eq("  42")
   end
+
+  it "access to the program with @top_level" do
+    run(%(
+      class Foo
+        def bar
+          {{@top_level.name.stringify}}
+        end
+      end
+
+      Foo.new.bar
+      )).to_string.should eq("top_level")
+  end
+
+  it "responds correctly to has_constant? with @top_level" do
+    run(%(
+      FOO = 1
+      class Foo
+        def bar
+          {{@top_level.has_constant?("FOO")}}
+        end
+      end
+
+      Foo.new.bar
+      )).to_b.should eq(true)
+  end
 end

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -546,6 +546,8 @@ module Crystal
       when "@type"
         target = @scope == @program.class_type ? @scope : @scope.instance_type
         @last = TypeNode.new(target.devirtualize)
+      when "@top_level"
+        @last = TypeNode.new(@program)
       when "@def"
         @last = @def || NilLiteral.new
       else

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -123,7 +123,7 @@ module Crystal
     property compiler : Compiler?
 
     def initialize
-      super(self, self, "main")
+      super(self, self, "top_level")
 
       # Every crystal program comes with some predefined types that we initialize here,
       # like Object, Value, Reference, etc.


### PR DESCRIPTION
Co-authored-by: Ary Borenszweig <asterite@gmail.com>